### PR TITLE
Amusement-based permission system. Added all commands to permission requirements

### DIFF
--- a/core/cmd.js
+++ b/core/cmd.js
@@ -29,7 +29,7 @@ const buildTree = (args, perm) => {
     })
 }
 
-const trigger = (ctx, args, type) => {
+const trigger = (ctx, args, roles) => {
     let cursor = tree
 
     if(args.length === 0)
@@ -45,7 +45,7 @@ const trigger = (ctx, args, type) => {
     }
 
     if (cursor._perm) {
-        if(!type || !cursor._perm.find(x => x === type))
+        if(!roles || !cursor._perm.find(x => roles.includes(x)))
             return ctx.error(`Only users with ayano roles **[${cursor._perm}]** can execute this command`)
     }
 

--- a/core/index.js
+++ b/core/index.js
@@ -17,7 +17,7 @@ const ctx = {
 
     allowExit: true,
 
-    input: async (argv, type) => {
+    input: async (argv, roles) => {
         try {
             /*const mainOptions = commandLineArgs(
                 [{ name: 'command', defaultOption: true }], { argv, stopAtFirstUnknown: true })
@@ -25,7 +25,7 @@ const ctx = {
             mainOptions.command = mainOptions.command || 'default'*/
 
             argv = argv.filter(n => n)
-            await trigger(ctx, argv, type)
+            await trigger(ctx, argv, roles)
 
             if(ctx.allowExit) process.exit(0)
         } catch(e) {

--- a/core/with.js
+++ b/core/with.js
@@ -3,6 +3,7 @@ const {
     readOrDefault,
 } = require('./utils')
 const { createInterface }   = require('../modules/cli')
+const MongoClient           = require('mongodb').MongoClient;
 
 const withConfig = callback => (ctx, ...args) => {
     if(ctx.config)
@@ -60,14 +61,14 @@ const withDB = callback => async (ctx, ...args) => {
     if(!ctx.config)
         return ctx.error(`Config is required to connect to database. Please provide config first`)
 
-    if(ctx.mcn)
+    if(ctx.db)
         return callback(ctx, ...args)
 
     ctx.info(`Connecting to database`)
     const mongoUri = ctx.config.database
     const mongoOpt = {useNewUrlParser: true, useUnifiedTopology: true}
 
-    ctx.mcn = await require('mongoose').connect(mongoUri, mongoOpt)
+    ctx.db = (await MongoClient.connect(mongoUri, mongoOpt)).db('amusement2')
     ctx.info(`Successfully connected to database`)
 
     return callback(ctx, ...args)

--- a/modules/cli.js
+++ b/modules/cli.js
@@ -18,7 +18,7 @@ const createInterface = (ctx) => {
         if (line === "quit" || line === "q")
             return readLine.close()
 
-        await ctx.input(line.split(' '), 'admin')
+        await ctx.input(line.split(' '), ['admin'])
         readLine.prompt()
 
     }).on('close', async () => {

--- a/modules/misc.js
+++ b/modules/misc.js
@@ -1,5 +1,5 @@
 
-const { cmd } = require('../core/cmd')
+const { pcmd } = require('../core/cmd')
 const { 
     withData,
 } = require('../core/with')
@@ -26,5 +26,5 @@ const flushdata = (ctx) => {
     })(ctx)
 }
 
-cmd(['stress'], stress)
-cmd(['flushdata'], flushdata)
+pcmd(['admin'],['stress'], stress)
+pcmd(['admin'],['flushdata'], flushdata)

--- a/modules/promo.js
+++ b/modules/promo.js
@@ -3,7 +3,7 @@
 * Used by CLI and bot
 */
 
-const { cmd }           = require('../core/cmd')
+const { pcmd }           = require('../core/cmd')
 const { modules }       = require('amusementclub2.0')
 const { 
     withData,
@@ -103,5 +103,5 @@ const addBoost = async (ctx, ...args) => {
     return ctx.info(`Created new boost: **${boost.name}** with **${boost.cards.length}** cards`)
 }
 
-cmd(['promo'], withData(addPromo))
-cmd(['boost'], withData(addBoost))
+pcmd(['admin'],['promo'], withData(addPromo))
+pcmd(['admin'],['boost'], withData(addBoost))

--- a/modules/s3.js
+++ b/modules/s3.js
@@ -1,5 +1,5 @@
 
-const { cmd }           = require('../core/cmd')
+const { pcmd }           = require('../core/cmd')
 const commandLineArgs   = require('command-line-args')
 const write             = require('./write')
 
@@ -141,7 +141,7 @@ const getCardObject = (name, collection) => {
     }
 }
 
-cmd(['update'], withConfig(withData(withS3(update))))
+pcmd(['admin'], ['update'], withConfig(withData(withS3(update))))
 
 module.exports = { 
     rename: withConfig(withS3(rename))

--- a/modules/s3.js
+++ b/modules/s3.js
@@ -141,7 +141,7 @@ const getCardObject = (name, collection) => {
     }
 }
 
-pcmd(['admin'], ['update'], withConfig(withData(withS3(update))))
+pcmd(['admin', 'cardmod'], ['update'], withConfig(withData(withS3(update))))
 
 module.exports = { 
     rename: withConfig(withS3(rename))

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -78,6 +78,6 @@ const unbanword = async (ctx, ...args) => {
     ctx.info(`Removed \`${word}\` from the list of banned words`)
 }
 
-pcmd(['admin', 'mod'], ['rename'], withData(rename))
+pcmd(['admin', 'cardmod'], ['rename'], withData(rename))
 pcmd(['admin', 'mod'], ['banword'], withData(banword))
 pcmd(['admin', 'mod'], ['unbanword'], withData(unbanword))

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -1,5 +1,5 @@
 
-const { cmd }       = require('../core/cmd')
+const { pcmd }       = require('../core/cmd')
 const { modules }   = require('amusementclub2.0')
 const write         = require('./write')
 const s3            = require('./s3')
@@ -78,6 +78,6 @@ const unbanword = async (ctx, ...args) => {
     ctx.info(`Removed \`${word}\` from the list of banned words`)
 }
 
-cmd(['rename'], withData(rename))
-cmd(['banword'], withData(banword))
-cmd(['unbanword'], withData(unbanword))
+pcmd(['admin', 'mod'], ['rename'], withData(rename))
+pcmd(['admin', 'mod'], ['banword'], withData(banword))
+pcmd(['admin', 'mod'], ['unbanword'], withData(unbanword))


### PR DESCRIPTION
Since ayano requires amusementclub. I figured this would be the best and easiest route into implementing ayano mods, as it means there would be no need to restart ayano to add a new mod. Only add their role in amusement and they'll be eligible in ayano.


Let me know if there are permission changes you want before merging. 